### PR TITLE
Move antigen to home dir

### DIFF
--- a/home/.zsh/shrc/00-antigen.zsh
+++ b/home/.zsh/shrc/00-antigen.zsh
@@ -6,7 +6,7 @@
 
 # Download and source the antigen plugin system
 local ANTIGEN_DIR="${HOME}/.antigen"
-local ANTIGEN="${ANTIGEN_DIR}/.antigen.zsh"
+local ANTIGEN="${ANTIGEN_DIR}/antigen.zsh"
 
 if [[ ! -d "${ANTIGEN_DIR}" ]]; then
     mkdir -p "${ANTIGEN_DIR}"

--- a/home/.zsh/shrc/00-antigen.zsh
+++ b/home/.zsh/shrc/00-antigen.zsh
@@ -4,8 +4,13 @@
 # Mike Barker <mike@thebarkers.com>
 # June 9th, 2019
 
-local ANTIGEN="${HOME}/antigen.zsh"
+# Download and source the antigen plugin system
+local ANTIGEN_DIR="${HOME}/.antigen"
+local ANTIGEN="${ANTIGEN_DIR}/.antigen.zsh"
 
+if [[ ! -d "${ANTIGEN_DIR}" ]]; then
+    mkdir -p "${ANTIGEN_DIR}"
+fi
 if [[ ! -e "${ANTIGEN}" ]]; then
     curl -L git.io/antigen > ${ANTIGEN}
 fi


### PR DESCRIPTION
Moved the antigen startup script to the ~/.antigen dir
This will allow docker containers to link a volume to
share the antigen plugin system.