### PR TITLE
Remove starship config

### DIFF
--- a/home/.config/starship.toml
+++ b/home/.config/starship.toml
@@ -1,3 +1,0 @@
-# Disable the package module, hiding it from the prompt completely
-[aws]
-disabled = true

--- a/install
+++ b/install
@@ -58,6 +58,5 @@ link_glob() {
 # Backup existing files and link files/dirs in the home folder into
 # the users home directory.
 pushd ./home > /dev/null
-link_glob ".config/*" "${HOME}"
 link_glob ".z*" "${HOME}"
 popd > /dev/null


### PR DESCRIPTION
I moved the starship config file to its own repository.
I kept the starship init script in this repository,
My thinking is that each shell should initialize the
prompt the way they wish, hoever the prompt config should
be shell agnostic.