### PR TITLE
Fix path issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,12 @@ $ ./install
 ```
 
 ## Configuration
-I am using the ['antigen'](http://antigen.sharats.me/) zsh plugin manager to configure and manage my zsh configuration.
+I use ['oh-my-zsh'](https://ohmyz.sh/) to manage my zsh configuration.
+Oh My Zsh is an open source, community-driven framework for managing your Zsh configuration..
+
+## Notes
+
+### Path issues
+On macOS, if you set the path in the *recommended* file `~/.zshenv` the system will overwrite it when it runs `/etc/zprofile` later in the startup.
+My solution is to source the `~/.zshenv` file in `~/.zprofile` if running on macOS aka 'Darwin'.
+

--- a/home/.zprofile
+++ b/home/.zprofile
@@ -4,3 +4,6 @@
 # Mike Barker <mike@thebarkers.com>
 # November 3rd, 2022
 
+# On macOS (darwin), source the ~/.zshenv file to fix the path
+[[ $OSTYPE =~ "darwin" ]] && source ~/.zshenv
+

--- a/home/.zshenv
+++ b/home/.zshenv
@@ -12,35 +12,13 @@ if [[ -d ${HOME}/.env ]]; then
     done
 fi
 
-# Configure the path
-
 # If on macos, use path_helper to seed the path
-if [ -x /usr/libexec/path_helper ]; then
-	eval `/usr/libexec/path_helper -s`
-    # I modified /etc/zprofile to not eval the path_helper if
-    # NO_PATH_HELPER exists.
-    # This keeps the path from getting clobbered by path_helper.
-    NO_PATH_HELPER=1
+PATH_HELPER=/usr/libexec/path_helper
+if [[ -x  $PATH_HELPER ]]; then
+    unset PATH
+    eval $($PATH_HELPER -s)
 fi
-
-
-# Add before existing path
-newpath+=(
-~/bin
-~/.local/bin
-~/.dotnet/tools
-/opt/microsoft/bin)
-
-# Add existing path
-newpath+=($path)
-
-# Add after existing path
-newpath+=(/usr/local/sbin)
-
-# Compose the path from the newpath array,
-# only existing paths will be added to the new path.
-path=($^newpath(N))
-
+unset PATH_HELPER
 
 # Configure homebrew environment
 BREW=""
@@ -69,3 +47,31 @@ fi
 if [[ $(command -v rbenv) ]]; then
     eval "$(rbenv init -)"
 fi
+
+## Configure the path
+# Feel free to add system specific paths here
+# since any path that does not exist on the
+# current system will not be added to the
+# system path.
+ 
+# Add paths before the existing system path
+newpath=(
+~/bin
+~/.local/bin
+~/.dotnet/tools
+/opt/microsoft/bin)
+
+# Add existing system paths to the newpath
+newpath+=($path)
+
+# Add paths to the newpath
+newpath+=(/usr/local/sbin)
+
+# Replace the system path using the newpath array,
+# only existing paths will be added to the new path.
+path=($^newpath(N))
+
+# Remove duplicate entries from the system path
+typeset -U path
+unset newpath
+


### PR DESCRIPTION
On macOS the path is being set in /etc/zprofile
this is overwriting the path that I have set in ~/.zshenv!
The solution I settled on was:
add code to ~/.zprofile to check the current OS,
if it is macOS then source the ~/.zhenv file. 
Thus reseting the path to the *correct* configuration.
I also refactored ~/.zshenv to make sure the path was being
configured correctly.