### PR TITLE
Fix Xterm prompt

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -51,8 +51,8 @@ fi
 # If set to an empty array, this variable will have no effect.
 # ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
 
-# If starship is installed, use it
-if [[ $(command -v starship) ]]; then
+# If starship is installed and not running in xterm, use it
+if [[ $(command -v starship) ]] && [[ $TERM != xterm ]]; then
     # Starship Cross Platform Prompt
     # The minimal, blazing-fast, and infinitely customizable prompt for any shell!
     # https://starship.rs/


### PR DESCRIPTION
The prompt app 'starship' does not work well on xterm. I added a check to only enable it when zsh is not being run from an xterm.