### PR TITLE
Disable prompt if TERM is dumb

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -51,19 +51,22 @@ fi
 # If set to an empty array, this variable will have no effect.
 # ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
 
-# If starship is installed and not running in xterm, use it
-if [[ $(command -v starship) ]] && [[ $TERM != xterm ]]; then
-    # Starship Cross Platform Prompt
-    # The minimal, blazing-fast, and infinitely customizable prompt for any shell!
-    # https://starship.rs/
-    # The ~/.config/starship.toml file is used to configure the prompt.
-    eval "$(starship init zsh)"
-else
-    # Spaceship theme
-    # https://denysdovhan.com/spaceship-prompt/
-    ZSH_THEME="spaceship"
-    # Disable kubecontext
-    export SPACESHIP_KUBECTL_CONTEXT_SHOW='false'
+# Only setup a prompt if the term is not dumb (emacs shell)
+if [[ $TERM != dumb ]]; then
+    # If starship is installed and not running in xterm, use it
+    if [[ $(command -v starship) ]] && [[ $TERM != xterm ]]; then
+	# Starship Cross Platform Prompt
+	# The minimal, blazing-fast, and infinitely customizable prompt for any shell!
+	# https://starship.rs/
+	# The ~/.config/starship.toml file is used to configure the prompt.
+	eval "$(starship init zsh)"
+    else
+	# Spaceship theme
+	# https://denysdovhan.com/spaceship-prompt/
+	ZSH_THEME="spaceship"
+	# Disable kubecontext
+	export SPACESHIP_KUBECTL_CONTEXT_SHOW='false'
+    fi
 fi
 
 # Uncomment the following line to use case-sensitive completion.
@@ -123,6 +126,7 @@ zstyle ':omz:update' frequency 7
 plugins=(
     command-not-found
     dotenv
+    emacs
     kubectl
     fzf
     git
@@ -176,4 +180,3 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
-


### PR DESCRIPTION
I added this to allow zsh to be used by the emacs 'shell' command.